### PR TITLE
Add login authentication and Heroku setup

### DIFF
--- a/ECApp/ECApp/settings.py
+++ b/ECApp/ECApp/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = "django-insecure-8(*9+(lcl-cghdp(@f+o8keri*_njntk!6^ia)45$o=aq((@j4
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "").split(",") if os.environ.get("ALLOWED_HOSTS") else ["*"]
 
 
 # Application definition
@@ -117,11 +117,14 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = "static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+LOGIN_URL = "login"
+LOGIN_REDIRECT_URL = "/"
 
 # OpenAI API key configuration
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")

--- a/ECApp/ECApp/urls.py
+++ b/ECApp/ECApp/urls.py
@@ -17,8 +17,11 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import path, include
+from django.contrib.auth import views as auth_views
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("login/", auth_views.LoginView.as_view(template_name="registration/login.html"), name="login"),
+    path("logout/", auth_views.LogoutView.as_view(next_page="login"), name="logout"),
     path("", include("descriptions.urls")),
 ]

--- a/ECApp/descriptions/templates/registration/login.html
+++ b/ECApp/descriptions/templates/registration/login.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 400px;
+            margin: 50px auto;
+            padding: 20px;
+            border-radius: 10px;
+            background: #f9f9f9;
+        }
+        form {
+            display: flex;
+            flex-direction: column;
+        }
+        input {
+            margin: 5px 0;
+            padding: 8px;
+            font-size: 1rem;
+        }
+        button {
+            padding: 10px;
+            margin-top: 10px;
+            background-color: #4a90e2;
+            border: none;
+            color: #fff;
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+    <h1>Login</h1>
+    {% if form.errors %}
+        <p style="color:red;">Invalid username or password.</p>
+    {% endif %}
+    <form method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit">Log in</button>
+    </form>
+</body>
+</html>

--- a/ECApp/descriptions/views.py
+++ b/ECApp/descriptions/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 from django.views import View
+from django.contrib.auth.mixins import LoginRequiredMixin
 from openai import OpenAI
 from dotenv import load_dotenv
 import base64
@@ -21,8 +22,9 @@ Given the user's written observation and photo(s) of a child’s activity, write
 Your evaluation must be objective, grounded only in the provided inputs. Do not speculate or describe the child’s appearance or clothing.
 """
 
-class EvaluationView(View):
+class EvaluationView(LoginRequiredMixin, View):
     template_name = "descriptions/evaluate.html"
+    login_url = "login"
 
     def get(self, request):
         return render(request, self.template_name)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This is a simple Django web application for early childhood educators to upload photos of classroom activities and receive automated descriptions using the OpenAI API. The project is ready for deployment on Heroku.
 
+Users must log in before accessing the evaluation form. Create a superuser with:
+```bash
+python ECApp/manage.py createsuperuser
+```
+Then sign in at `/login/`.
+
 ## Local Setup
 
 1. Install dependencies:
@@ -20,4 +26,4 @@ This is a simple Django web application for early childhood educators to upload 
 
 ## Deployment
 
-Create a Heroku app and push this repository. Heroku will detect the `Procfile` and use `gunicorn` to serve the application. Ensure the `OPENAI_API_KEY` config var is set in Heroku.
+Create a Heroku app and push this repository. Heroku will detect the `Procfile` and use `gunicorn` to serve the application. Set the `OPENAI_API_KEY` and `ALLOWED_HOSTS` config vars in Heroku so the app can authenticate and serve requests.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django>=5.2.1
 openai>=1.14.0
 gunicorn>=21.2
+python-dotenv>=1.0


### PR DESCRIPTION
## Summary
- require login for evaluation view
- add login and logout routes with template
- configure allowed hosts, static root and login settings
- document login step and Heroku env vars
- include python-dotenv in requirements

## Testing
- `pip install -r requirements.txt`
- `python ECApp/manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6857b67426ec8332961772a16ce95e19